### PR TITLE
Feature/add md file to xxx mcp tools

### DIFF
--- a/.env.test.sample
+++ b/.env.test.sample
@@ -1,4 +1,4 @@
-MIDDLEMAN_BASE_URL_VCR=https://middleman-ai.com
+MIDDLEMAN_BASE_URL=https://middleman-ai.com
 MIDDLEMAN_API_KEY_VCR=your_test_api_key
 MIDDLEMAN_TEST_PDF_TEMPLATE_ID=your_test_pdf_template_id
 MIDDLEMAN_TEST_PPTX_TEMPLATE_ID=your_test_pptx_template_id

--- a/README-for-developer.md
+++ b/README-for-developer.md
@@ -23,7 +23,8 @@ Claude Desktop アプリケーションの`claude_desktop_config.json`を以下�
       "command": "/path/to/python",
       "args": ["/path/to/middleman_ai/mcp/server.py"],
       "env": {
-        "MIDDLEMAN_API_KEY": "xxxxx"
+        "MIDDLEMAN_API_KEY": "xxxxx",
+        "MIDDLEMAN_BASE_URL_VCR": "http://0.0.0.0:8000"
       }
     }
   }

--- a/README-for-developer.md
+++ b/README-for-developer.md
@@ -24,7 +24,7 @@ Claude Desktop アプリケーションの`claude_desktop_config.json`を以下�
       "args": ["/path/to/middleman_ai/mcp/server.py"],
       "env": {
         "MIDDLEMAN_API_KEY": "xxxxx",
-        "MIDDLEMAN_BASE_URL_VCR": "http://0.0.0.0:8000"
+        "MIDDLEMAN_BASE_URL": "http://0.0.0.0:8000"
       }
     }
   }
@@ -53,7 +53,7 @@ Claude Desktop アプリケーションの`claude_desktop_config.json`を以下�
       ],
       "env": {
         "MIDDLEMAN_API_KEY": "xxxxx",
-        "MIDDLEMAN_BASE_URL_VCR": "https://stg.middleman-ai.com/"
+        "MIDDLEMAN_BASE_URL": "https://stg.middleman-ai.com/"
       }
     }
   }

--- a/README-for-developer.md
+++ b/README-for-developer.md
@@ -33,6 +33,8 @@ Claude Desktop アプリケーションの`claude_desktop_config.json`を以下�
 
 ### PyPI テスト環境で MCP サーバー実行
 
+⚠ 配布直後、最新のバージョンが反映されるまで数分かかることがあります。
+
 ```json
 {
   "mcpServers": {
@@ -46,11 +48,12 @@ Claude Desktop アプリケーションの`claude_desktop_config.json`を以下�
         "--index-strategy",
         "unsafe-best-match",
         "--from",
-        "middleman-ai==0.0.x",
+        "middleman-ai",
         "mcp-server"
       ],
       "env": {
-        "MIDDLEMAN_API_KEY": "xxxxx"
+        "MIDDLEMAN_API_KEY": "xxxxx",
+        "MIDDLEMAN_BASE_URL_VCR": "https://stg.middleman-ai.com/"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "middleman-ai"
-version = "0.1.1.0"
+version = "0.1.1"
 description = "Python client SDK for Middleman.ai API"
 authors = [{ name = "Generative Agents, Inc." }]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "middleman-ai"
-version = "0.1.0"
+version = "0.1.1.0"
 description = "Python client SDK for Middleman.ai API"
 authors = [{ name = "Generative Agents, Inc." }]
 dependencies = [

--- a/src/middleman_ai/mcp/server.py
+++ b/src/middleman_ai/mcp/server.py
@@ -17,7 +17,7 @@ print(f"Current directory: {os.getcwd()}", file=sys.stderr)
 mcp = FastMCP("Middleman Tools")
 
 api_key = os.environ.get("MIDDLEMAN_API_KEY", "")
-base_url = os.environ.get("MIDDLEMAN_BASE_URL_VCR", "https://middleman-ai.com/")
+base_url = os.environ.get("MIDDLEMAN_BASE_URL", "https://middleman-ai.com/")
 client = ToolsClient(api_key=api_key, base_url=base_url)
 
 

--- a/src/middleman_ai/mcp/server.py
+++ b/src/middleman_ai/mcp/server.py
@@ -16,7 +16,8 @@ print(f"Current directory: {os.getcwd()}", file=sys.stderr)
 mcp = FastMCP("Middleman Tools")
 
 api_key = os.environ.get("MIDDLEMAN_API_KEY", "")
-client = ToolsClient(api_key=api_key)
+base_url = os.environ.get("MIDDLEMAN_BASE_URL_VCR", "https://middleman-ai.com/")
+client = ToolsClient(api_key=api_key, base_url=base_url)
 
 
 @mcp.tool()

--- a/src/middleman_ai/mcp/server.py
+++ b/src/middleman_ai/mcp/server.py
@@ -50,10 +50,15 @@ def md_file_to_pdf(md_file_full_path: str, pdf_template_id: str | None = None) -
     Returns:
         The URL to download the generated PDF
     """
-    if not md_file_full_path.startswith("/"):
-        raise ValueError("md_file_full_path must start with '/'")
+    file_path = Path(md_file_full_path)
+    if not file_path.exists():
+        raise ValueError(f"File not found: {md_file_full_path}")
+    if not file_path.is_file():
+        raise ValueError(f"Path is not a file: {md_file_full_path}")
+    if not os.access(file_path, os.R_OK):
+        raise ValueError(f"File not readable: {md_file_full_path}")
 
-    with Path(md_file_full_path).open("r") as f:
+    with file_path.open("r") as f:
         md_text = f.read()
     return client.md_to_pdf(md_text, pdf_template_id=pdf_template_id)
 
@@ -83,10 +88,15 @@ def md_file_to_docx(md_file_full_path: str) -> str:
     Returns:
         The URL to download the generated DOCX
     """
-    if not md_file_full_path.startswith("/"):
-        raise ValueError("md_file_full_path must start with '/'")
+    file_path = Path(md_file_full_path)
+    if not file_path.exists():
+        raise ValueError(f"File not found: {md_file_full_path}")
+    if not file_path.is_file():
+        raise ValueError(f"Path is not a file: {md_file_full_path}")
+    if not os.access(file_path, os.R_OK):
+        raise ValueError(f"File not readable: {md_file_full_path}")
 
-    with Path(md_file_full_path).open("r") as f:
+    with file_path.open("r") as f:
         md_text = f.read()
     return client.md_to_docx(md_text)
 

--- a/src/middleman_ai/mcp/server.py
+++ b/src/middleman_ai/mcp/server.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from typing import Any, Dict, List
 
 from mcp.server.fastmcp import FastMCP
@@ -37,6 +38,27 @@ def md_to_pdf(markdown_text: str, pdf_template_id: str | None = None) -> str:
 
 
 @mcp.tool()
+def md_file_to_pdf(md_file_full_path: str, pdf_template_id: str | None = None) -> str:
+    """
+    Convert a Markdown file to PDF and return the download URL.
+
+    Args:
+        md_file_full_path: Path to the local Markdown file
+        pdf_template_id: Optional ID of the PDF template to use.
+        If not provided, the default template will be used
+
+    Returns:
+        The URL to download the generated PDF
+    """
+    if not md_file_full_path.startswith("/"):
+        raise ValueError("md_file_full_path must start with '/'")
+
+    with Path(md_file_full_path).open("r") as f:
+        md_text = f.read()
+    return client.md_to_pdf(md_text, pdf_template_id=pdf_template_id)
+
+
+@mcp.tool()
 def md_to_docx(markdown_text: str) -> str:
     """
     Convert Markdown text to DOCX and return the download URL.
@@ -48,6 +70,25 @@ def md_to_docx(markdown_text: str) -> str:
         The URL to download the generated DOCX
     """
     return client.md_to_docx(markdown_text)
+
+
+@mcp.tool()
+def md_file_to_docx(md_file_full_path: str) -> str:
+    """
+    Convert a Markdown file to DOCX and return the download URL.
+
+    Args:
+        md_file_full_path: Path to the local Markdown file
+
+    Returns:
+        The URL to download the generated DOCX
+    """
+    if not md_file_full_path.startswith("/"):
+        raise ValueError("md_file_full_path must start with '/'")
+
+    with Path(md_file_full_path).open("r") as f:
+        md_text = f.read()
+    return client.md_to_docx(md_text)
 
 
 @mcp.tool()

--- a/tests/test_client_vcr.py
+++ b/tests/test_client_vcr.py
@@ -21,7 +21,7 @@ def client() -> ToolsClient:
         ToolsClient: テスト用のクライアントインスタンス
     """
     return ToolsClient(
-        base_url=os.getenv("MIDDLEMAN_BASE_URL_VCR") or "https://middleman-ai.com",
+        base_url=os.getenv("MIDDLEMAN_BASE_URL") or "https://middleman-ai.com",
         api_key=os.getenv("MIDDLEMAN_API_KEY_VCR") or "",
     )
 

--- a/tests/test_langchain_tools_vcr.py
+++ b/tests/test_langchain_tools_vcr.py
@@ -31,7 +31,7 @@ def client() -> ToolsClient:
         ToolsClient: テスト用のクライアントインスタンス
     """
     return ToolsClient(
-        base_url=os.getenv("MIDDLEMAN_BASE_URL_VCR") or "https://middleman-ai.com",
+        base_url=os.getenv("MIDDLEMAN_BASE_URL") or "https://middleman-ai.com",
         api_key=os.getenv("MIDDLEMAN_API_KEY_VCR") or "",
     )
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -10,6 +10,8 @@ from middleman_ai.mcp.server import (
     json_to_pptx_analyze,
     json_to_pptx_execute,
     mcp,
+    md_file_to_docx,
+    md_file_to_pdf,
     md_to_docx,
     md_to_pdf,
     pdf_to_page_images,
@@ -150,3 +152,51 @@ def test_run_server(mocker: "MockerFixture") -> None:
     run_server()
 
     mock_mcp.run.assert_called_once_with(transport="stdio")
+
+
+def test_md_file_to_pdf_tool(mocker: "MockerFixture") -> None:
+    """md_file_to_pdfツールのテスト。"""
+    mock_client = mocker.patch("middleman_ai.mcp.server.client")
+    mock_path = mocker.patch("middleman_ai.mcp.server.Path")
+    mock_os_access = mocker.patch("middleman_ai.mcp.server.os.access")
+    # mock_open を変数に束縛せず、Pathオブジェクトのopenメソッドのモックを設定
+    mock_file_handle = mocker.MagicMock()
+    mock_file_handle.read.return_value = "# Test MD"
+    mock_path.return_value.open.return_value.__enter__.return_value = mock_file_handle
+
+    mock_path.return_value.exists.return_value = True
+    mock_path.return_value.is_file.return_value = True
+    mock_client.md_to_pdf.return_value = "https://example.com/test_file.pdf"
+
+    file_path = "/fake/path/to/test.md"
+    result = md_file_to_pdf(file_path)
+
+    assert result == "https://example.com/test_file.pdf"
+    mock_path.assert_called_once_with(file_path)
+    mock_path.return_value.open.assert_called_once_with("r")
+    mock_client.md_to_pdf.assert_called_once_with("# Test MD", pdf_template_id=None)
+    mock_os_access.assert_called_once_with(mock_path.return_value, mocker.ANY)
+
+
+def test_md_file_to_docx_tool(mocker: "MockerFixture") -> None:
+    """md_file_to_docxツールのテスト。"""
+    mock_client = mocker.patch("middleman_ai.mcp.server.client")
+    mock_path = mocker.patch("middleman_ai.mcp.server.Path")
+    mock_os_access = mocker.patch("middleman_ai.mcp.server.os.access")
+    # mock_open を変数に束縛せず、Pathオブジェクトのopenメソッドのモックを設定
+    mock_file_handle = mocker.MagicMock()
+    mock_file_handle.read.return_value = "# Test MD"
+    mock_path.return_value.open.return_value.__enter__.return_value = mock_file_handle
+
+    mock_path.return_value.exists.return_value = True
+    mock_path.return_value.is_file.return_value = True
+    mock_client.md_to_docx.return_value = "https://example.com/test_file.docx"
+
+    file_path = "/fake/path/to/test.md"
+    result = md_file_to_docx(file_path)
+
+    assert result == "https://example.com/test_file.docx"
+    mock_path.assert_called_once_with(file_path)
+    mock_path.return_value.open.assert_called_once_with("r")
+    mock_client.md_to_docx.assert_called_once_with("# Test MD")
+    mock_os_access.assert_called_once_with(mock_path.return_value, mocker.ANY)

--- a/uv.lock
+++ b/uv.lock
@@ -593,7 +593,7 @@ wheels = [
 
 [[package]]
 name = "middleman-ai"
-version = "0.1.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -593,7 +593,7 @@ wheels = [
 
 [[package]]
 name = "middleman-ai"
-version = "0.1.0"
+version = "0.1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 関連

- [ファイルパスを指定して、その内容をpdfやdocxに変換できるようにしたい](https://github.com/GenerativeAgents/middleman/issues/306)
- [SDKのMCPをSTG環境に向けて動作確認できる仕組みを用意する](https://github.com/GenerativeAgents/middleman/issues/334)

## 対応事項

- MCPにツールを追加し、mdファイルのPDFまたはDOCX変換時に、ファイルパスの指定で直接mdファイルから変換できるようになりました。
- ローカル環境 および STG環境でMCP実行時の挙動が不定だったため、ドキュメントを整備しました。

## テスト
- 単体テスト追加
- ローカルで動作確認済み（ドキュメント更新済み）
- STG環境で動作確認済み（ドキュメント更新済み）https://test.pypi.org/project/middleman-ai/#history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ローカルMarkdownファイルからPDFまたはDOCXファイルを生成し、ダウンロードURLを返すツールを追加しました。

- **ドキュメント**
  - 開発者向けREADMEに環境変数`MIDDLEMAN_BASE_URL`の設定例や注意事項を追記しました。

- **テスト**
  - 新ツール機能のテストを追加しました。
  - テスト用環境変数名を一部変更しました。

- **その他**
  - プロジェクトバージョンを0.1.1に更新しました。
  - サンプル環境変数ファイルを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->