### PR TITLE
md-to-docxのテンプレートID指定機能を追加 & テスト周りの改善

### DIFF
--- a/.env.test.sample
+++ b/.env.test.sample
@@ -1,4 +1,4 @@
 MIDDLEMAN_BASE_URL=https://middleman-ai.com
-MIDDLEMAN_API_KEY_VCR=your_test_api_key
+MIDDLEMAN_API_KEY=your_test_api_key
 MIDDLEMAN_TEST_PDF_TEMPLATE_ID=your_test_pdf_template_id
 MIDDLEMAN_TEST_PPTX_TEMPLATE_ID=your_test_pptx_template_id

--- a/README-for-developer.md
+++ b/README-for-developer.md
@@ -53,7 +53,7 @@ Claude Desktop アプリケーションの`claude_desktop_config.json`を以下�
       ],
       "env": {
         "MIDDLEMAN_API_KEY": "xxxxx",
-        "MIDDLEMAN_BASE_URL": "https://stg.middleman-ai.com/"
+        "MIDDLEMAN_BASE_URL": "${各環境のAPIベースURL}"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ lint.ignore = ["RUF001", "RUF002", "RUF022", "N818"]
 [tool.ruff.isort]
 known-first-party = ["middleman_ai"]
 
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/*.py" = ["PLR2004"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/middleman_ai/cli/main.py
+++ b/src/middleman_ai/cli/main.py
@@ -54,7 +54,8 @@ def md_to_pdf(template_id: str | None = None) -> None:
 
 
 @cli.command()
-def md_to_docx() -> None:
+@click.argument("template_id", required=False)
+def md_to_docx(template_id: str | None = None) -> None:
     """Convert Markdown to DOCX."""
     print("md_to_docx コマンドを実行しています...")
     try:
@@ -68,9 +69,11 @@ def md_to_docx() -> None:
             length=1, label="DOCXに変換中...", show_eta=False
         ) as bar:
             print("APIを呼び出しています...")
-            docx_url = client.md_to_docx(markdown_text)
+            docx_url = client.md_to_docx(markdown_text, docx_template_id=template_id)
             bar.update(1)
         print(f"変換結果URL: {docx_url}")
+        if template_id:
+            print(f"使用したテンプレートID: {template_id}")
     except MiddlemanBaseException as e:
         print(f"エラーが発生しました: {e!s}")
         raise click.ClickException(str(e)) from e

--- a/src/middleman_ai/client.py
+++ b/src/middleman_ai/client.py
@@ -155,6 +155,7 @@ class ToolsClient:
 
         Args:
             markdown_text: 変換対象のMarkdown文字列
+            pdf_template_id: テンプレートID(UUID)
 
         Returns:
             str: 生成されたPDFのURL
@@ -180,11 +181,16 @@ class ToolsClient:
         except requests.exceptions.RequestException as e:
             raise ConnectionError() from e
 
-    def md_to_docx(self, markdown_text: str) -> str:
+    def md_to_docx(
+        self,
+        markdown_text: str,
+        docx_template_id: str | None = None,
+    ) -> str:
         """Markdown文字列をDOCXに変換し、DOCXのダウンロードURLを返します。
 
         Args:
             markdown_text: 変換対象のMarkdown文字列
+            docx_template_id: テンプレートID(UUID)
 
         Returns:
             str: 生成されたDOCXのURL
@@ -196,7 +202,10 @@ class ToolsClient:
         try:
             response = self.session.post(
                 f"{self.base_url}/api/v1/tools/md-to-docx",
-                json={"markdown": markdown_text},
+                json={
+                    "markdown": markdown_text,
+                    "template_id": docx_template_id,
+                },
                 timeout=self.timeout,
             )
             data = self._handle_response(response)

--- a/src/middleman_ai/client.py
+++ b/src/middleman_ai/client.py
@@ -204,7 +204,7 @@ class ToolsClient:
                 f"{self.base_url}/api/v1/tools/md-to-docx",
                 json={
                     "markdown": markdown_text,
-                    "template_id": docx_template_id,
+                    "docx_template_id": docx_template_id,
                 },
                 timeout=self.timeout,
             )

--- a/src/middleman_ai/exceptions.py
+++ b/src/middleman_ai/exceptions.py
@@ -19,6 +19,10 @@ class NotEnoughCreditError(MiddlemanBaseException):
     """クレジット不足によりAPIの実行ができません。"""
 
 
+class BadRequestError(MiddlemanBaseException):
+    """リクエストが不正です。"""
+
+
 class ForbiddenError(MiddlemanBaseException):
     """APIキーが無効か、アクセス権限がありません。"""
 

--- a/src/middleman_ai/langchain_tools/md_to_docx.py
+++ b/src/middleman_ai/langchain_tools/md_to_docx.py
@@ -44,6 +44,7 @@ class MdToDocxTool(BaseTool):
 
         Args:
             client: Middleman.ai APIクライアント
+            default_template_id: デフォルトのDOCXテンプレートのID（UUID）
             **kwargs: BaseTool用の追加引数
         """
         kwargs["client"] = client

--- a/src/middleman_ai/mcp/server.py
+++ b/src/middleman_ai/mcp/server.py
@@ -64,26 +64,30 @@ def md_file_to_pdf(md_file_full_path: str, pdf_template_id: str | None = None) -
 
 
 @mcp.tool()
-def md_to_docx(markdown_text: str) -> str:
+def md_to_docx(markdown_text: str, docx_template_id: str | None = None) -> str:
     """
     Convert Markdown text to DOCX and return the download URL.
 
     Args:
         markdown_text: The Markdown text to convert
+        docx_template_id: Optional ID of the DOCX template to use.
+        If not provided, the default template will be used
 
     Returns:
         The URL to download the generated DOCX
     """
-    return client.md_to_docx(markdown_text)
+    return client.md_to_docx(markdown_text, docx_template_id=docx_template_id)
 
 
 @mcp.tool()
-def md_file_to_docx(md_file_full_path: str) -> str:
+def md_file_to_docx(md_file_full_path: str, docx_template_id: str | None = None) -> str:
     """
     Convert a Markdown file to DOCX and return the download URL.
 
     Args:
         md_file_full_path: Path to the local Markdown file
+        docx_template_id: Optional ID of the DOCX template to use.
+        If not provided, the default template will be used
 
     Returns:
         The URL to download the generated DOCX
@@ -98,7 +102,7 @@ def md_file_to_docx(md_file_full_path: str) -> str:
 
     with file_path.open("r") as f:
         md_text = f.read()
-    return client.md_to_docx(md_text)
+    return client.md_to_docx(md_text, docx_template_id=docx_template_id)
 
 
 @mcp.tool()

--- a/tests/cassettes/test_json_to_pptx_analyze_tool_vcr.yaml
+++ b/tests/cassettes/test_json_to_pptx_analyze_tool_vcr.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"pptx_template_id": "19823658-6af5-4560-ab87-632da39511de"}'
+    body: '{"pptx_template_id": "TEMPLATE_ID"}'
     headers:
       Accept:
       - '*/*'
@@ -31,15 +31,24 @@ interactions:
         title"}]},{"position":2,"type":"Common","description":"Please use this slide
         to create content.","placeholders":[{"name":"title","description":"Input slide
         title here"},{"name":"content","description":"Input slide content here"},{"name":"image","description":"Input
-        slide image url here"}]}],"json_to_pptx_presentation_schema":{"$defs":{"Placeholder":{"properties":{"name":{"description":"The
-        key of the placeholder","title":"Name","type":"string"},"content":{"description":"The
-        content of the placeholder","title":"Content","type":"string"}},"required":["name","content"],"title":"Placeholder","type":"object"},"Slide":{"properties":{"type":{"description":"The
-        type of the slide","title":"Type","type":"string"},"placeholders":{"description":"The
-        placeholders of the slide","items":{"$ref":"#/$defs/Placeholder"},"title":"Placeholders","type":"array"},"speaker_notes":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null,"description":"Additional
-        notes for the slide intended for the presenter. These notes provide extra
-        context or cues during the presentation and are not visible to the audience.","title":"Speaker
-        Notes"}},"required":["type","placeholders"],"title":"Slide","type":"object"}},"properties":{"slides":{"description":"The
-        slides of the presentation","items":{"$ref":"#/$defs/Slide"},"title":"Slides","type":"array"}},"required":["slides"],"title":"Presentation","type":"object"}}'
+        slide image url here"}]}],"json_to_pptx_presentation_schema":"{\"$defs\":
+        {\"Placeholder\": {\"properties\": {\"name\": {\"description\": \"The key
+        of the placeholder\", \"title\": \"Name\", \"type\": \"string\"}, \"content\":
+        {\"description\": \"The content of the placeholder\", \"title\": \"Content\",
+        \"type\": \"string\"}}, \"required\": [\"name\", \"content\"], \"title\":
+        \"Placeholder\", \"type\": \"object\"}, \"Slide\": {\"properties\": {\"type\":
+        {\"description\": \"The type of the slide\", \"title\": \"Type\", \"type\":
+        \"string\"}, \"placeholders\": {\"description\": \"The placeholders of the
+        slide\", \"items\": {\"$ref\": \"#/$defs/Placeholder\"}, \"title\": \"Placeholders\",
+        \"type\": \"array\"}, \"speaker_notes\": {\"anyOf\": [{\"type\": \"string\"},
+        {\"type\": \"null\"}], \"default\": null, \"description\": \"Additional notes
+        for the slide intended for the presenter. These notes provide extra context
+        or cues during the presentation and are not visible to the audience.\", \"title\":
+        \"Speaker Notes\"}}, \"required\": [\"type\", \"placeholders\"], \"title\":
+        \"Slide\", \"type\": \"object\"}}, \"properties\": {\"slides\": {\"description\":
+        \"The slides of the presentation\", \"items\": {\"$ref\": \"#/$defs/Slide\"},
+        \"title\": \"Slides\", \"type\": \"array\"}}, \"required\": [\"slides\"],
+        \"title\": \"Presentation\", \"type\": \"object\"}"}'
     headers:
       content-encoding:
       - gzip

--- a/tests/cassettes/test_json_to_pptx_analyze_v2_vcr.yaml
+++ b/tests/cassettes/test_json_to_pptx_analyze_v2_vcr.yaml
@@ -1,63 +1,64 @@
 interactions:
-- request:
-    body: '{"pptx_template_id": "19823658-6af5-4560-ab87-632da39511de"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, zstd
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '60'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-      authorization:
-      - DUMMY
-    method: POST
-    uri: https://middleman-ai.com/api/v2/tools/json-to-pptx/analyze
-  response:
-    body:
-      string: '{"important_remark_for_user":"- The ''slides'' field contains the slides
-        definition provided in the template.\n- Generate the presentation content
-        by filling in the placeholder values for the slide you selected to use according
-        to the JSON schema defined in ''json_to_pptx_presentation_schema''.\n- When
-        calling the json-to-pptx/execute endpoint, use the provided schema to structure
-        your ''presentation'' field data. \n- The URL expires in 1 hour. Please note
-        that you will not be able to download the file after it has expired.","slides":[{"position":1,"type":"Title","description":"Please
-        use this slide to create title slide of presentation","placeholders":[{"name":"title","description":"Presentation
-        title"}]},{"position":2,"type":"Common","description":"Please use this slide
-        to create content.","placeholders":[{"name":"title","description":"Input slide
-        title here"},{"name":"content","description":"Input slide content here"},{"name":"image","description":"Input
-        slide image url here"}]}],"json_to_pptx_presentation_schema":{"$defs":{"Placeholder":{"properties":{"name":{"description":"The
-        key of the placeholder","title":"Name","type":"string"},"content":{"description":"The
-        content of the placeholder","title":"Content","type":"string"}},"required":["name","content"],"title":"Placeholder","type":"object"},"Slide":{"properties":{"type":{"description":"The
-        type of the slide","title":"Type","type":"string"},"placeholders":{"description":"The
-        placeholders of the slide","items":{"$ref":"#/$defs/Placeholder"},"title":"Placeholders","type":"array"},"speaker_notes":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null,"description":"Additional
-        notes for the slide intended for the presenter. These notes provide extra
-        context or cues during the presentation and are not visible to the audience.","title":"Speaker
-        Notes"}},"required":["type","placeholders"],"title":"Slide","type":"object"}},"properties":{"slides":{"description":"The
-        slides of the presentation","items":{"$ref":"#/$defs/Slide"},"title":"Slides","type":"array"}},"required":["slides"],"title":"Presentation","type":"object"}}'
-    headers:
-      content-encoding:
-      - gzip
-      content-type:
-      - application/json
-      date:
-      - FILTERED
-      server:
-      - FILTERED
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-middleware-rewrite:
-      - FILTERED
-      x-request-id:
-      - FILTERED
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: '{"pptx_template_id": "TEMPLATE_ID"}'
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate, zstd
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "60"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - python-requests/2.32.3
+        authorization:
+          - DUMMY
+      method: POST
+      uri: https://middleman-ai.com/api/v2/tools/json-to-pptx/analyze
+    response:
+      body:
+        string:
+          '{"important_remark_for_user":"- The ''slides'' field contains the slides
+          definition provided in the template.\n- Generate the presentation content
+          by filling in the placeholder values for the slide you selected to use according
+          to the JSON schema defined in ''json_to_pptx_presentation_schema''.\n- When
+          calling the json-to-pptx/execute endpoint, use the provided schema to structure
+          your ''presentation'' field data. \n- The URL expires in 1 hour. Please note
+          that you will not be able to download the file after it has expired.","slides":[{"position":1,"type":"Title","description":"Please
+          use this slide to create title slide of presentation","placeholders":[{"name":"title","description":"Presentation
+          title"}]},{"position":2,"type":"Common","description":"Please use this slide
+          to create content.","placeholders":[{"name":"title","description":"Input slide
+          title here"},{"name":"content","description":"Input slide content here"},{"name":"image","description":"Input
+          slide image url here"}]}],"json_to_pptx_presentation_schema":{"$defs":{"Placeholder":{"properties":{"name":{"description":"The
+          key of the placeholder","title":"Name","type":"string"},"content":{"description":"The
+          content of the placeholder","title":"Content","type":"string"}},"required":["name","content"],"title":"Placeholder","type":"object"},"Slide":{"properties":{"type":{"description":"The
+          type of the slide","title":"Type","type":"string"},"placeholders":{"description":"The
+          placeholders of the slide","items":{"$ref":"#/$defs/Placeholder"},"title":"Placeholders","type":"array"},"speaker_notes":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null,"description":"Additional
+          notes for the slide intended for the presenter. These notes provide extra
+          context or cues during the presentation and are not visible to the audience.","title":"Speaker
+          Notes"}},"required":["type","placeholders"],"title":"Slide","type":"object"}},"properties":{"slides":{"description":"The
+          slides of the presentation","items":{"$ref":"#/$defs/Slide"},"title":"Slides","type":"array"}},"required":["slides"],"title":"Presentation","type":"object"}}'
+      headers:
+        content-encoding:
+          - gzip
+        content-type:
+          - application/json
+        date:
+          - FILTERED
+        server:
+          - FILTERED
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        x-middleware-rewrite:
+          - FILTERED
+        x-request-id:
+          - FILTERED
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/cassettes/test_json_to_pptx_execute_tool_vcr.yaml
+++ b/tests/cassettes/test_json_to_pptx_execute_tool_vcr.yaml
@@ -1,7 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"pptx_template_id": "19823658-6af5-4560-ab87-632da39511de", "presentation":
+      body: '{"pptx_template_id": "TEMPLATE_ID", "presentation":
         {"slides": [{"type": "title", "placeholders": [{"name": "title", "content":
         "Test Title"}, {"name": "subtitle", "content": "Test Subtitle"}]}]}}'
       headers:

--- a/tests/cassettes/test_json_to_pptx_execute_v2_vcr.yaml
+++ b/tests/cassettes/test_json_to_pptx_execute_v2_vcr.yaml
@@ -1,7 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"pptx_template_id": "19823658-6af5-4560-ab87-632da39511de", "presentation":
+      body: '{"pptx_template_id": "TEMPLATE_ID", "presentation":
         {"slides": [{"type": "title", "placeholders": [{"name": "title", "content":
         "Test Title"}, {"name": "subtitle", "content": "Test Subtitle"}]}]}}'
       headers:

--- a/tests/cassettes/test_md_to_docx_tool_vcr.yaml
+++ b/tests/cassettes/test_md_to_docx_tool_vcr.yaml
@@ -2,7 +2,7 @@ interactions:
   - request:
       body:
         '{"markdown": "# Test Heading\n\n    This is a test markdown document.\n\n    ##
-        Section 1\n    - Item 1\n    - Item 2\n    "}'
+        Section 1\n    - Item 1\n    - Item 2\n    ", "template_id": null}'
       headers:
         Accept:
           - "*/*"

--- a/tests/cassettes/test_md_to_docx_vcr.yaml
+++ b/tests/cassettes/test_md_to_docx_vcr.yaml
@@ -2,7 +2,7 @@ interactions:
   - request:
       body:
         '{"markdown": "# Test Heading\n\n    This is a test markdown document.\n\n    ##
-        Section 1\n    - Item 1\n    - Item 2\n    ", "template_id": null}'
+        Section 1\n    - Item 1\n    - Item 2\n    ", "docx_template_id": null}'
       headers:
         Accept:
           - "*/*"

--- a/tests/cassettes/test_md_to_docx_vcr.yaml
+++ b/tests/cassettes/test_md_to_docx_vcr.yaml
@@ -2,7 +2,7 @@ interactions:
   - request:
       body:
         '{"markdown": "# Test Heading\n\n    This is a test markdown document.\n\n    ##
-        Section 1\n    - Item 1\n    - Item 2\n    "}'
+        Section 1\n    - Item 1\n    - Item 2\n    ", "template_id": null}'
       headers:
         Accept:
           - "*/*"

--- a/tests/cassettes/test_md_to_docx_with_template_id_vcr.yaml
+++ b/tests/cassettes/test_md_to_docx_with_template_id_vcr.yaml
@@ -19,11 +19,11 @@ interactions:
         authorization:
           - DUMMY
       method: POST
-      uri: https://stg.middleman-ai.com/api/v1/tools/md-to-docx
+      uri: https://middleman-ai.com/api/v1/tools/md-to-docx
     response:
       body:
         string:
-          '{"docx_url":"https://stg.middleman-ai.com/s/abfbc7fe/scLdYIML1z","important_remark_for_user":"The
+          '{"docx_url":"https://middleman-ai.com/s/abfbc7fe/scLdYIML1z","important_remark_for_user":"The
           URL expires in 1 hour.Please note that you will not be able to download the
           file after it has expired."}'
       headers:

--- a/tests/cassettes/test_md_to_docx_with_template_id_vcr.yaml
+++ b/tests/cassettes/test_md_to_docx_with_template_id_vcr.yaml
@@ -2,7 +2,7 @@ interactions:
   - request:
       body:
         '{"markdown": "# Test Heading\n\n    This is a test markdown document.\n\n    ##
-        Section 1\n    - Item 1\n    - Item 2\n    ", "docx_template_id": null}'
+        Section 1\n    - Item 1\n    - Item 2\n    ", "docx_template_id": "TEMPLATE_ID"}'
       headers:
         Accept:
           - "*/*"
@@ -11,7 +11,7 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "125"
+          - "180"
         Content-Type:
           - application/json
         User-Agent:
@@ -19,11 +19,11 @@ interactions:
         authorization:
           - DUMMY
       method: POST
-      uri: https://middleman-ai.com/api/v1/tools/md-to-docx
+      uri: https://stg.middleman-ai.com/api/v1/tools/md-to-docx
     response:
       body:
         string:
-          '{"docx_url":"https://middleman-ai.com/s/709dd3af/zljyFkYtnl","important_remark_for_user":"The
+          '{"docx_url":"https://stg.middleman-ai.com/s/abfbc7fe/scLdYIML1z","important_remark_for_user":"The
           URL expires in 1 hour.Please note that you will not be able to download the
           file after it has expired."}'
       headers:

--- a/tests/cassettes/test_md_to_pdf_with_template_id_vcr.yaml
+++ b/tests/cassettes/test_md_to_pdf_with_template_id_vcr.yaml
@@ -2,7 +2,7 @@ interactions:
   - request:
       body:
         '{"markdown": "# Test Heading\n\n    This is a test markdown document.\n\n    ##
-        Section 1\n    - Item 1\n    - Item 2\n    ", "pdf_template_id": "a978ae98-d4c6-430e-a049-1f377b5d25d1"}'
+        Section 1\n    - Item 1\n    - Item 2\n    ", "pdf_template_id": "TEMPLATE_ID"}'
       headers:
         Accept:
           - "*/*"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3,14 +3,10 @@
 """Tests for the CLI implementation."""
 
 import json
-import os
 
 import click
 
 from middleman_ai.cli.main import cli
-
-# Set dummy API key for tests
-os.environ["MIDDLEMAN_API_KEY"] = "test-key"
 
 
 def test_md_to_pdf(runner, mock_client):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,7 +9,7 @@ import click
 from middleman_ai.cli.main import cli
 
 
-def test_md_to_pdf(runner, mock_client):
+def test_md_to_pdf_cli(runner, mock_client):
     """Test md_to_pdf CLI command."""
     mock_client.md_to_pdf.return_value = "https://example.com/test.pdf"
     result = runner.invoke(cli, ["md-to-pdf"], input="# Test")
@@ -18,16 +18,36 @@ def test_md_to_pdf(runner, mock_client):
     mock_client.md_to_pdf.assert_called_once_with("# Test", pdf_template_id=None)
 
 
-def test_md_to_docx(runner, mock_client):
+def test_md_to_pdf_cli_with_template_id(runner, mock_client):
+    mock_client.md_to_pdf.return_value = "https://example.com/test.pdf"
+    result = runner.invoke(cli, ["md-to-pdf", "TEMPLATE_ID"], input="# Test")
+    assert result.exit_code == 0
+    assert "https://example.com/test.pdf" in result.output
+    mock_client.md_to_pdf.assert_called_once_with(
+        "# Test", pdf_template_id="TEMPLATE_ID"
+    )
+
+
+def test_md_to_docx_cli(runner, mock_client):
     """Test md_to_docx CLI command."""
     mock_client.md_to_docx.return_value = "https://example.com/test.docx"
     result = runner.invoke(cli, ["md-to-docx"], input="# Test")
     assert result.exit_code == 0
     assert "https://example.com/test.docx" in result.output
-    mock_client.md_to_docx.assert_called_once_with("# Test")
+    mock_client.md_to_docx.assert_called_once_with("# Test", docx_template_id=None)
 
 
-def test_pdf_to_page_images(runner, mock_client, tmp_path):
+def test_md_to_docx_cli_with_template_id(runner, mock_client):
+    mock_client.md_to_docx.return_value = "https://example.com/test.docx"
+    result = runner.invoke(cli, ["md-to-docx", "TEMPLATE_ID"], input="# Test")
+    assert result.exit_code == 0
+    assert "https://example.com/test.docx" in result.output
+    mock_client.md_to_docx.assert_called_once_with(
+        "# Test", docx_template_id="TEMPLATE_ID"
+    )
+
+
+def test_pdf_to_page_images_cli(runner, mock_client, tmp_path):
     """Test pdf_to_page_images CLI command."""
     mock_client.pdf_to_page_images.return_value = [
         {"page_no": 1, "image_url": "https://example.com/page1.png"},
@@ -42,7 +62,7 @@ def test_pdf_to_page_images(runner, mock_client, tmp_path):
     mock_client.pdf_to_page_images.assert_called_once_with(str(pdf_path))
 
 
-def test_json_to_pptx_analyze(runner, mock_client):
+def test_json_to_pptx_analyze_cli(runner, mock_client):
     """Test json_to_pptx_analyze CLI command."""
     mock_client.json_to_pptx_analyze_v2.return_value = [
         {"type": "title", "placeholders": [{"name": "title", "content": ""}]}
@@ -53,7 +73,7 @@ def test_json_to_pptx_analyze(runner, mock_client):
     mock_client.json_to_pptx_analyze_v2.assert_called_once_with("template-123")
 
 
-def test_json_to_pptx_execute(runner, mock_client):
+def test_json_to_pptx_execute_cli(runner, mock_client):
     """Test json_to_pptx_execute CLI command."""
     mock_client.json_to_pptx_execute_v2.return_value = "https://example.com/result.pptx"
     input_data = {
@@ -72,7 +92,7 @@ def test_json_to_pptx_execute(runner, mock_client):
     mock_client.json_to_pptx_execute_v2.assert_called_once()
 
 
-def test_missing_api_key(runner, mocker):
+def test_missing_api_key_cli(runner, mocker):
     """Test error handling when API key is missing."""
     mocker.patch(
         "middleman_ai.cli.main.get_api_key",
@@ -83,7 +103,7 @@ def test_missing_api_key(runner, mocker):
     assert "API key not set" in result.output
 
 
-def test_invalid_json_input(runner, mock_client):
+def test_invalid_json_input_cli(runner, mock_client):
     """Test error handling for invalid JSON input."""
     result = runner.invoke(
         cli, ["json-to-pptx-execute", "template-123"], input="invalid json"
@@ -92,7 +112,7 @@ def test_invalid_json_input(runner, mock_client):
     assert "Invalid JSON input" in result.output
 
 
-def test_pptx_to_page_images(runner, mock_client, tmp_path) -> None:
+def test_pptx_to_page_images_cli(runner, mock_client, tmp_path) -> None:
     """Test pptx_to_page_images CLI command."""
     mock_client.pptx_to_page_images.return_value = [
         {"page_no": 1, "image_url": "https://example.com/slide1.png"},
@@ -107,7 +127,7 @@ def test_pptx_to_page_images(runner, mock_client, tmp_path) -> None:
     mock_client.pptx_to_page_images.assert_called_once_with(str(pptx_path))
 
 
-def test_docx_to_page_images(runner, mock_client, tmp_path) -> None:
+def test_docx_to_page_images_cli(runner, mock_client, tmp_path) -> None:
     """Test docx_to_page_images CLI command."""
     mock_client.docx_to_page_images.return_value = [
         {"page_no": 1, "image_url": "https://example.com/page1.png"},
@@ -122,7 +142,7 @@ def test_docx_to_page_images(runner, mock_client, tmp_path) -> None:
     mock_client.docx_to_page_images.assert_called_once_with(str(docx_path))
 
 
-def test_xlsx_to_page_images(runner, mock_client, tmp_path) -> None:
+def test_xlsx_to_page_images_cli(runner, mock_client, tmp_path) -> None:
     """Test xlsx_to_page_images CLI command."""
     mock_client.xlsx_to_page_images.return_value = [
         {"sheet_name": "Sheet1", "image_url": "https://example.com/sheet1.png"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,10 @@ VCRHTTPResponse.version_string = property(_get_version_string, _set_version_stri
 
 
 def scrub_uri_request(request: Any) -> Any:
-    """リクエストのURI からホスト名を標準化してmiddleman-ai.comに置換する"""
+    """
+    リクエストのURI からホスト名を標準化してmiddleman-ai.comに置換する
+    本番環境以外のURLが露出することを避けるための処置です
+    """
     req = copy.deepcopy(request)  # ミュータブルに触らず安全に
     p = urlparse(req.uri)
     redacted = urlunparse(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,7 +46,7 @@ def test_init(client: ToolsClient) -> None:
     """初期化のテスト。"""
     assert client.api_key == "test_api_key"
     assert client.base_url == "https://middleman-ai.com"
-    assert client.timeout == 30.0  # noqa: PLR2004
+    assert client.timeout == 30.0
     assert client.session.headers["Authorization"] == "Bearer test_api_key"
     assert client.session.headers["Content-Type"] == "application/json"
 

--- a/tests/test_client_vcr.py
+++ b/tests/test_client_vcr.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from middleman_ai.client import Presentation, ToolsClient
-from tests.vcr_utils import generate_filter_request_body_function
 
 if TYPE_CHECKING:
     from _pytest.fixtures import FixtureRequest  # noqa: F401
@@ -46,11 +45,7 @@ def test_md_to_pdf_vcr(client: ToolsClient) -> None:
     assert "/s/" in pdf_url
 
 
-@pytest.mark.vcr(
-    before_record_request=generate_filter_request_body_function(
-        "pdf_template_id", "TEMPLATE_ID"
-    ),
-)
+@pytest.mark.vcr()
 def test_md_to_pdf_with_template_id_vcr(client: ToolsClient) -> None:
     """ToolsClient.md_to_pdfの実際のAPIを使用したテスト。
 
@@ -95,12 +90,7 @@ def test_md_to_docx_vcr(client: ToolsClient) -> None:
     assert "/s/" in docx_url
 
 
-@pytest.mark.vcr(
-    before_record_request=generate_filter_request_body_function(
-        "docx_template_id",
-        "TEMPLATE_ID",
-    ),
-)
+@pytest.mark.vcr()
 def test_md_to_docx_with_template_id_vcr(client: ToolsClient) -> None:
     """ToolsClient.md_to_docxの実際のAPIを使用したテスト。
 
@@ -144,12 +134,7 @@ def test_pdf_to_page_images_vcr(client: ToolsClient) -> None:
     assert all("/s/" in page["image_url"] for page in pages)
 
 
-@pytest.mark.vcr(
-    before_record_request=generate_filter_request_body_function(
-        "pptx_template_id",
-        "TEMPLATE_ID",
-    ),
-)
+@pytest.mark.vcr()
 def test_json_to_pptx_analyze_v2_vcr(client: ToolsClient) -> None:
     """ToolsClient.json_to_pptx_analyze_v2の実際のAPIを使用したテスト。
 
@@ -176,12 +161,7 @@ def test_json_to_pptx_analyze_v2_vcr(client: ToolsClient) -> None:
         assert all("description" in placeholder for placeholder in placeholders)
 
 
-@pytest.mark.vcr(
-    before_record_request=generate_filter_request_body_function(
-        "pptx_template_id",
-        "TEMPLATE_ID",
-    ),
-)
+@pytest.mark.vcr()
 def test_json_to_pptx_execute_v2_vcr(client: ToolsClient) -> None:
     """ToolsClient.json_to_pptx_execute_v2の実際のAPIを使用したテスト。
 

--- a/tests/test_client_vcr.py
+++ b/tests/test_client_vcr.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from middleman_ai.client import Presentation, ToolsClient
+from tests.vcr_utils import generate_filter_request_body_function
 
 if TYPE_CHECKING:
     from _pytest.fixtures import FixtureRequest  # noqa: F401
@@ -45,7 +46,11 @@ def test_md_to_pdf_vcr(client: ToolsClient) -> None:
     assert "/s/" in pdf_url
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(
+    before_record_request=generate_filter_request_body_function(
+        "pdf_template_id", "TEMPLATE_ID"
+    ),
+)
 def test_md_to_pdf_with_template_id_vcr(client: ToolsClient) -> None:
     """ToolsClient.md_to_pdfの実際のAPIを使用したテスト。
 
@@ -90,6 +95,35 @@ def test_md_to_docx_vcr(client: ToolsClient) -> None:
     assert "/s/" in docx_url
 
 
+@pytest.mark.vcr(
+    before_record_request=generate_filter_request_body_function(
+        "docx_template_id",
+        "TEMPLATE_ID",
+    ),
+)
+def test_md_to_docx_with_template_id_vcr(client: ToolsClient) -> None:
+    """ToolsClient.md_to_docxの実際のAPIを使用したテスト。
+
+    Note:
+        このテストは実際のAPIを呼び出し、レスポンスをキャッシュします。
+        初回実行時のみAPIを呼び出し、以降はキャッシュを使用します。
+    """
+    test_markdown = """# Test Heading
+
+    This is a test markdown document.
+
+    ## Section 1
+    - Item 1
+    - Item 2
+    """
+    docx_url = client.md_to_docx(
+        markdown_text=test_markdown,
+        docx_template_id=os.getenv("MIDDLEMAN_TEST_DOCX_TEMPLATE_ID") or "",
+    )
+    assert docx_url.startswith("https://")
+    assert "/s/" in docx_url
+
+
 # マルチパートの場合リクエストごとにファイルがどこで分割されるかが異なるようなので
 # bodyをマッチ判定の対象外にしている
 @pytest.mark.vcr(match_on=["method", "scheme", "port", "path", "query"])
@@ -110,7 +144,12 @@ def test_pdf_to_page_images_vcr(client: ToolsClient) -> None:
     assert all("/s/" in page["image_url"] for page in pages)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(
+    before_record_request=generate_filter_request_body_function(
+        "pptx_template_id",
+        "TEMPLATE_ID",
+    ),
+)
 def test_json_to_pptx_analyze_v2_vcr(client: ToolsClient) -> None:
     """ToolsClient.json_to_pptx_analyze_v2の実際のAPIを使用したテスト。
 
@@ -137,7 +176,12 @@ def test_json_to_pptx_analyze_v2_vcr(client: ToolsClient) -> None:
         assert all("description" in placeholder for placeholder in placeholders)
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(
+    before_record_request=generate_filter_request_body_function(
+        "pptx_template_id",
+        "TEMPLATE_ID",
+    ),
+)
 def test_json_to_pptx_execute_v2_vcr(client: ToolsClient) -> None:
     """ToolsClient.json_to_pptx_execute_v2の実際のAPIを使用したテスト。
 

--- a/tests/test_client_vcr.py
+++ b/tests/test_client_vcr.py
@@ -20,7 +20,7 @@ def client() -> ToolsClient:
     """
     return ToolsClient(
         base_url=os.getenv("MIDDLEMAN_BASE_URL") or "https://middleman-ai.com",
-        api_key=os.getenv("MIDDLEMAN_API_KEY_VCR") or "",
+        api_key=os.getenv("MIDDLEMAN_API_KEY") or "",
     )
 
 

--- a/tests/test_client_vcr.py
+++ b/tests/test_client_vcr.py
@@ -1,5 +1,3 @@
-# ruff: noqa: PLR2004
-
 """LangChainツール群のVCRテストモジュール。"""
 
 import os

--- a/tests/test_langchain_tools.py
+++ b/tests/test_langchain_tools.py
@@ -35,7 +35,7 @@ def test_md_to_pdf_tool(client: ToolsClient, mocker: "MockerFixture") -> None:
     )
 
     tool = MdToPdfTool(client=client)
-    result = tool._run("# Test")
+    result = tool.run("# Test")
 
     assert result == "https://example.com/test.pdf"
     mock_md_to_pdf.assert_called_once_with("# Test", pdf_template_id=None)
@@ -52,7 +52,12 @@ def test_md_to_pdf_tool_with_template_id(
     )
 
     tool = MdToPdfTool(client=client)
-    result = tool._run("# Test", pdf_template_id="00000000-0000-0000-0000-000000000001")
+    result = tool.run(
+        {
+            "text": "# Test",
+            "pdf_template_id": "00000000-0000-0000-0000-000000000001",
+        }
+    )
 
     assert result == "https://example.com/test.pdf"
     mock_md_to_pdf.assert_called_once_with(
@@ -75,7 +80,7 @@ def test_md_to_pdf_tool_with_default_template_id(
         client=client,
         default_template_id="00000000-0000-0000-0000-000000000001",
     )
-    result = tool._run("# Test")
+    result = tool.run("# Test")
 
     assert result == "https://example.com/test.pdf"
     mock_md_to_pdf.assert_called_once_with(
@@ -98,9 +103,11 @@ def test_md_to_pdf_tool_with_both_template_id_and_default_template_id(
         client=client,
         default_template_id="00000000-0000-0000-0000-000000000001",
     )
-    result = tool._run(
-        "# Test",
-        pdf_template_id="00000000-0000-0000-0000-000000000002",
+    result = tool.run(
+        {
+            "text": "# Test",
+            "pdf_template_id": "00000000-0000-0000-0000-000000000002",
+        }
     )
 
     assert result == "https://example.com/test.pdf"
@@ -119,10 +126,89 @@ def test_md_to_docx_tool(client: ToolsClient, mocker: "MockerFixture") -> None:
     )
 
     tool = MdToDocxTool(client=client)
-    result = tool._run("# Test")
+    result = tool.run("# Test")
 
     assert result == "https://example.com/test.docx"
-    mock_md_to_docx.assert_called_once_with("# Test")
+    mock_md_to_docx.assert_called_once_with("# Test", docx_template_id=None)
+
+
+def test_md_to_docx_tool_with_template_id(
+    client: ToolsClient,
+    mocker: "MockerFixture",
+) -> None:
+    """MdToDocxToolのテスト。"""
+    mock_md_to_docx = mocker.patch.object(
+        client,
+        "md_to_docx",
+        return_value="https://example.com/test.docx",
+    )
+
+    tool = MdToDocxTool(client=client)
+    result = tool.run(
+        {
+            "text": "# Test",
+            "docx_template_id": "00000000-0000-0000-0000-000000000001",
+        }
+    )
+
+    assert result == "https://example.com/test.docx"
+    mock_md_to_docx.assert_called_once_with(
+        "# Test",
+        docx_template_id="00000000-0000-0000-0000-000000000001",
+    )
+
+
+def test_md_to_docx_tool_with_default_template_id(
+    client: ToolsClient,
+    mocker: "MockerFixture",
+) -> None:
+    """MdToDocxToolのテスト。"""
+    mock_md_to_docx = mocker.patch.object(
+        client,
+        "md_to_docx",
+        return_value="https://example.com/test.docx",
+    )
+
+    tool = MdToDocxTool(
+        client=client,
+        default_template_id="00000000-0000-0000-0000-000000000001",
+    )
+    result = tool.run("# Test")
+
+    assert result == "https://example.com/test.docx"
+    mock_md_to_docx.assert_called_once_with(
+        "# Test",
+        docx_template_id="00000000-0000-0000-0000-000000000001",
+    )
+
+
+def test_md_to_docx_tool_with_both_template_id_and_default_template_id(
+    client: ToolsClient,
+    mocker: "MockerFixture",
+) -> None:
+    """MdToDocxToolのテスト。"""
+    mock_md_to_docx = mocker.patch.object(
+        client,
+        "md_to_docx",
+        return_value="https://example.com/test.docx",
+    )
+
+    tool = MdToDocxTool(
+        client=client,
+        default_template_id="00000000-0000-0000-0000-000000000001",
+    )
+    result = tool.run(
+        {
+            "text": "# Test",
+            "docx_template_id": "00000000-0000-0000-0000-000000000002",
+        }
+    )
+
+    assert result == "https://example.com/test.docx"
+    mock_md_to_docx.assert_called_once_with(
+        "# Test",
+        docx_template_id="00000000-0000-0000-0000-000000000002",
+    )
 
 
 def test_pdf_to_page_images_tool(client: ToolsClient, mocker: "MockerFixture") -> None:
@@ -138,7 +224,7 @@ def test_pdf_to_page_images_tool(client: ToolsClient, mocker: "MockerFixture") -
     )
 
     tool = PdfToPageImagesTool(client=client)
-    result = tool._run("/path/to/test.pdf")
+    result = tool.run("/path/to/test.pdf")
 
     assert isinstance(result, str)
     assert "https://example.com/page1.png" in result
@@ -159,7 +245,7 @@ def test_pptx_to_page_images_tool(client: ToolsClient, mocker: "MockerFixture") 
     )
 
     tool = PptxToPageImagesTool(client=client)
-    result = tool._run("/path/to/test.pptx")
+    result = tool.run("/path/to/test.pptx")
 
     assert isinstance(result, str)
     assert "https://example.com/slide1.png" in result
@@ -180,7 +266,7 @@ def test_docx_to_page_images_tool(client: ToolsClient, mocker: "MockerFixture") 
     )
 
     tool = DocxToPageImagesTool(client=client)
-    result = tool._run("/path/to/test.docx")
+    result = tool.run("/path/to/test.docx")
 
     assert isinstance(result, str)
     assert "https://example.com/page1.png" in result
@@ -201,7 +287,7 @@ def test_xlsx_to_page_images_tool(client: ToolsClient, mocker: "MockerFixture") 
     )
 
     tool = XlsxToPageImagesTool(client=client)
-    result = tool._run("/path/to/test.xlsx")
+    result = tool.run("/path/to/test.xlsx")
 
     assert isinstance(result, str)
     assert "https://example.com/sheet1.png" in result
@@ -253,10 +339,10 @@ def test_json_to_pptx_analyze_tool_without_default_template_id(
 
     # テンプレートIDが指定されていない場合はエラー
     with pytest.raises(ValueError, match="テンプレートIDが指定されていません"):
-        tool._run("")
+        tool.run("")
 
     # テンプレートIDが指定された場合は成功
-    result = tool._run("template-123")
+    result = tool.run("template-123")
     assert isinstance(result, str)
     assert "Title Slide" in result
     assert "Content Slide" in result
@@ -312,7 +398,7 @@ def test_json_to_pptx_analyze_tool_with_default_template_id(
     )
 
     tool = JsonToPptxAnalyzeTool(client=client, default_template_id="template-123")
-    result = tool._run("")
+    result = tool.run("")
 
     assert isinstance(result, str)
     assert "Title Slide" in result
@@ -369,7 +455,7 @@ def test_json_to_pptx_analyze_tool_with_both_template_id_and_default_template_id
     )
 
     tool = JsonToPptxAnalyzeTool(client=client, default_template_id="template-123")
-    result = tool._run(template_id="template-456")
+    result = tool.run("template-456")
 
     assert isinstance(result, str)
     assert "Title Slide" in result
@@ -418,18 +504,22 @@ def test_json_to_pptx_execute_tool_without_default_template_id(
 
     # テンプレートIDが指定されていない場合はエラー
     with pytest.raises(ValueError, match="テンプレートIDが指定されていません"):
-        tool._run(
-            presentation=Presentation.model_validate(
-                presentation_data,
-            ).model_dump_json(),
+        tool.run(
+            {
+                "presentation": Presentation.model_validate(
+                    presentation_data,
+                ).model_dump_json(),
+            }
         )
 
     # テンプレートIDが指定された場合は成功
-    result = tool._run(
-        presentation=Presentation.model_validate(
-            presentation_data,
-        ).model_dump_json(),
-        template_id=template_id,
+    result = tool.run(
+        {
+            "presentation": Presentation.model_validate(
+                presentation_data,
+            ).model_dump_json(),
+            "template_id": template_id,
+        }
     )
     assert result == "https://example.com/result.pptx"
     mock_execute.assert_called_once_with(
@@ -470,10 +560,12 @@ def test_json_to_pptx_execute_tool_with_default_template_id(
     )
 
     tool = JsonToPptxExecuteTool(client=client, default_template_id=template_id)
-    result = tool._run(
-        presentation=Presentation.model_validate(
-            presentation_data,
-        ).model_dump_json(),
+    result = tool.run(
+        {
+            "presentation": Presentation.model_validate(
+                presentation_data,
+            ).model_dump_json(),
+        }
     )
 
     assert result == "https://example.com/result.pptx"
@@ -514,11 +606,13 @@ def test_json_to_pptx_execute_tool_with_both_template_id_and_default_template_id
     )
 
     tool = JsonToPptxExecuteTool(client=client, default_template_id="template-123")
-    result = tool._run(
-        presentation=Presentation.model_validate(
-            presentation_data,
-        ).model_dump_json(),
-        template_id="template-456",
+    result = tool.run(
+        {
+            "presentation": Presentation.model_validate(
+                presentation_data,
+            ).model_dump_json(),
+            "template_id": "template-456",
+        }
     )
 
     assert result == "https://example.com/result.pptx"
@@ -543,7 +637,7 @@ def test_json_to_pptx_analyze_tool_template_id_error(
     # テンプレートIDが指定されていない場合
     tool = JsonToPptxAnalyzeTool(client=client)
     with pytest.raises(ValueError, match="テンプレートIDが指定されていません"):
-        tool._run("")
+        tool.run("")
 
     mock_analyze.assert_not_called()
 
@@ -562,7 +656,11 @@ def test_json_to_pptx_execute_tool_template_id_error(
     tool = JsonToPptxExecuteTool(client=client)
     test_json = '{"slides": []}'
     with pytest.raises(ValueError, match="テンプレートIDが指定されていません"):
-        tool._run(test_json)
+        tool.run(
+            {
+                "presentation": test_json,
+            }
+        )
 
     mock_execute.assert_not_called()
 
@@ -579,6 +677,11 @@ def test_json_to_pptx_execute_tool_json_error(
 
     tool = JsonToPptxExecuteTool(client=client)
     with pytest.raises(ValueError, match="不正なJSON形式です"):
-        tool._run("invalid json", template_id="template-123")
+        tool.run(
+            {
+                "presentation": "invalid json",
+                "template_id": "template-123",
+            }
+        )
 
     mock_execute.assert_not_called()

--- a/tests/test_langchain_tools_vcr.py
+++ b/tests/test_langchain_tools_vcr.py
@@ -32,7 +32,7 @@ def client() -> ToolsClient:
     """
     return ToolsClient(
         base_url=os.getenv("MIDDLEMAN_BASE_URL") or "https://middleman-ai.com",
-        api_key=os.getenv("MIDDLEMAN_API_KEY_VCR") or "",
+        api_key=os.getenv("MIDDLEMAN_API_KEY") or "",
     )
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+import pytest
 from mcp.server.fastmcp import FastMCP
 
 from middleman_ai.client import Presentation, Slide
@@ -30,29 +31,120 @@ def test_mcp_instance() -> None:
     assert mcp.name == "Middleman Tools"
 
 
-def test_md_to_pdf_tool(mocker: "MockerFixture") -> None:
+@pytest.mark.parametrize(
+    "template_id",
+    [
+        None,
+        "123e4567-e89b-12d3-a456-426614174000",
+    ],
+)
+def test_md_to_pdf_tool_mcp(mocker: "MockerFixture", template_id: str | None) -> None:
     """md_to_pdfツールのテスト。"""
     mock_client = mocker.patch("middleman_ai.mcp.server.client")
     mock_client.md_to_pdf.return_value = "https://example.com/test.pdf"
 
-    result = md_to_pdf("# Test")
+    result = md_to_pdf("# Test", pdf_template_id=template_id)
 
     assert result == "https://example.com/test.pdf"
-    mock_client.md_to_pdf.assert_called_once_with("# Test", pdf_template_id=None)
+    mock_client.md_to_pdf.assert_called_once_with("# Test", pdf_template_id=template_id)
 
 
-def test_md_to_docx_tool(mocker: "MockerFixture") -> None:
+@pytest.mark.parametrize(
+    "template_id",
+    [
+        None,
+        "123e4567-e89b-12d3-a456-426614174000",
+    ],
+)
+def test_md_file_to_pdf_tool_mcp(
+    mocker: "MockerFixture",
+    template_id: str | None,
+) -> None:
+    """md_file_to_pdfツールのテスト。"""
+    mock_client = mocker.patch("middleman_ai.mcp.server.client")
+    mock_path = mocker.patch("middleman_ai.mcp.server.Path")
+    mock_os_access = mocker.patch("middleman_ai.mcp.server.os.access")
+    # mock_open を変数に束縛せず、Pathオブジェクトのopenメソッドのモックを設定
+    mock_file_handle = mocker.MagicMock()
+    mock_file_handle.read.return_value = "# Test MD"
+    mock_path.return_value.open.return_value.__enter__.return_value = mock_file_handle
+
+    mock_path.return_value.exists.return_value = True
+    mock_path.return_value.is_file.return_value = True
+    mock_client.md_to_pdf.return_value = "https://example.com/test_file.pdf"
+
+    file_path = "/fake/path/to/test.md"
+    result = md_file_to_pdf(file_path, pdf_template_id=template_id)
+
+    assert result == "https://example.com/test_file.pdf"
+    mock_path.assert_called_once_with(file_path)
+    mock_path.return_value.open.assert_called_once_with("r")
+    mock_client.md_to_pdf.assert_called_once_with(
+        "# Test MD",
+        pdf_template_id=template_id,
+    )
+    mock_os_access.assert_called_once_with(mock_path.return_value, mocker.ANY)
+
+
+@pytest.mark.parametrize(
+    "template_id",
+    [
+        None,
+        "123e4567-e89b-12d3-a456-426614174000",
+    ],
+)
+def test_md_to_docx_tool_mcp(mocker: "MockerFixture", template_id: str | None) -> None:
     """md_to_docxツールのテスト。"""
     mock_client = mocker.patch("middleman_ai.mcp.server.client")
     mock_client.md_to_docx.return_value = "https://example.com/test.docx"
 
-    result = md_to_docx("# Test")
+    result = md_to_docx("# Test", docx_template_id=template_id)
 
     assert result == "https://example.com/test.docx"
-    mock_client.md_to_docx.assert_called_once_with("# Test")
+    mock_client.md_to_docx.assert_called_once_with(
+        "# Test",
+        docx_template_id=template_id,
+    )
 
 
-def test_pptx_to_page_images_tool(mocker: "MockerFixture") -> None:
+@pytest.mark.parametrize(
+    "template_id",
+    [
+        None,
+        "123e4567-e89b-12d3-a456-426614174000",
+    ],
+)
+def test_md_file_to_docx_tool_mcp(
+    mocker: "MockerFixture",
+    template_id: str | None,
+) -> None:
+    """md_file_to_docxツールのテスト。"""
+    mock_client = mocker.patch("middleman_ai.mcp.server.client")
+    mock_path = mocker.patch("middleman_ai.mcp.server.Path")
+    mock_os_access = mocker.patch("middleman_ai.mcp.server.os.access")
+    # mock_open を変数に束縛せず、Pathオブジェクトのopenメソッドのモックを設定
+    mock_file_handle = mocker.MagicMock()
+    mock_file_handle.read.return_value = "# Test MD"
+    mock_path.return_value.open.return_value.__enter__.return_value = mock_file_handle
+
+    mock_path.return_value.exists.return_value = True
+    mock_path.return_value.is_file.return_value = True
+    mock_client.md_to_docx.return_value = "https://example.com/test_file.docx"
+
+    file_path = "/fake/path/to/test.md"
+    result = md_file_to_docx(file_path, docx_template_id=template_id)
+
+    assert result == "https://example.com/test_file.docx"
+    mock_path.assert_called_once_with(file_path)
+    mock_path.return_value.open.assert_called_once_with("r")
+    mock_client.md_to_docx.assert_called_once_with(
+        "# Test MD",
+        docx_template_id=template_id,
+    )
+    mock_os_access.assert_called_once_with(mock_path.return_value, mocker.ANY)
+
+
+def test_pptx_to_page_images_tool_mcp(mocker: "MockerFixture") -> None:
     """pptx_to_page_imagesツールのテスト。"""
     expected_result = [
         {"page_no": 1, "image_url": "https://example.com/slide1.png"},
@@ -67,7 +159,7 @@ def test_pptx_to_page_images_tool(mocker: "MockerFixture") -> None:
     mock_client.pptx_to_page_images.assert_called_once_with("/path/to/test.pptx")
 
 
-def test_docx_to_page_images_tool(mocker: "MockerFixture") -> None:
+def test_docx_to_page_images_tool_mcp(mocker: "MockerFixture") -> None:
     """docx_to_page_imagesツールのテスト。"""
     expected_result = [
         {"page_no": 1, "image_url": "https://example.com/page1.png"},
@@ -82,7 +174,7 @@ def test_docx_to_page_images_tool(mocker: "MockerFixture") -> None:
     mock_client.docx_to_page_images.assert_called_once_with("/path/to/test.docx")
 
 
-def test_xlsx_to_page_images_tool(mocker: "MockerFixture") -> None:
+def test_xlsx_to_page_images_tool_mcp(mocker: "MockerFixture") -> None:
     """xlsx_to_page_imagesツールのテスト。"""
     expected_result = [
         {"sheet_name": "Sheet1", "image_url": "https://example.com/sheet1.png"},
@@ -97,7 +189,7 @@ def test_xlsx_to_page_images_tool(mocker: "MockerFixture") -> None:
     mock_client.xlsx_to_page_images.assert_called_once_with("/path/to/test.xlsx")
 
 
-def test_pdf_to_page_images_tool(mocker: "MockerFixture") -> None:
+def test_pdf_to_page_images_tool_mcp(mocker: "MockerFixture") -> None:
     """pdf_to_page_imagesツールのテスト。"""
     expected_result = [
         {"page_no": 1, "image_url": "https://example.com/page1.png"},
@@ -112,7 +204,7 @@ def test_pdf_to_page_images_tool(mocker: "MockerFixture") -> None:
     mock_client.pdf_to_page_images.assert_called_once_with("/path/to/test.pdf")
 
 
-def test_json_to_pptx_analyze_tool(mocker: "MockerFixture") -> None:
+def test_json_to_pptx_analyze_tool_mcp(mocker: "MockerFixture") -> None:
     """json_to_pptx_analyzeツールのテスト。"""
     expected_result = {"slides": 5, "estimated_time": 10}
     mock_client_analyze = mocker.patch(
@@ -127,7 +219,7 @@ def test_json_to_pptx_analyze_tool(mocker: "MockerFixture") -> None:
     mock_client_analyze.assert_called_once_with(json_data["pptx_template_id"])
 
 
-def test_json_to_pptx_execute_tool(mocker: "MockerFixture") -> None:
+def test_json_to_pptx_execute_tool_mcp(mocker: "MockerFixture") -> None:
     """json_to_pptx_executeツールのテスト。"""
     expected_result = "https://example.com/generated.pptx"
     mock_execute = mocker.patch(
@@ -145,58 +237,10 @@ def test_json_to_pptx_execute_tool(mocker: "MockerFixture") -> None:
     mock_execute.assert_called_once_with(template_id, expected_arg)
 
 
-def test_run_server(mocker: "MockerFixture") -> None:
+def test_run_server_mcp(mocker: "MockerFixture") -> None:
     """run_serverのテスト。"""
     mock_mcp = mocker.patch("middleman_ai.mcp.server.mcp")
 
     run_server()
 
     mock_mcp.run.assert_called_once_with(transport="stdio")
-
-
-def test_md_file_to_pdf_tool(mocker: "MockerFixture") -> None:
-    """md_file_to_pdfツールのテスト。"""
-    mock_client = mocker.patch("middleman_ai.mcp.server.client")
-    mock_path = mocker.patch("middleman_ai.mcp.server.Path")
-    mock_os_access = mocker.patch("middleman_ai.mcp.server.os.access")
-    # mock_open を変数に束縛せず、Pathオブジェクトのopenメソッドのモックを設定
-    mock_file_handle = mocker.MagicMock()
-    mock_file_handle.read.return_value = "# Test MD"
-    mock_path.return_value.open.return_value.__enter__.return_value = mock_file_handle
-
-    mock_path.return_value.exists.return_value = True
-    mock_path.return_value.is_file.return_value = True
-    mock_client.md_to_pdf.return_value = "https://example.com/test_file.pdf"
-
-    file_path = "/fake/path/to/test.md"
-    result = md_file_to_pdf(file_path)
-
-    assert result == "https://example.com/test_file.pdf"
-    mock_path.assert_called_once_with(file_path)
-    mock_path.return_value.open.assert_called_once_with("r")
-    mock_client.md_to_pdf.assert_called_once_with("# Test MD", pdf_template_id=None)
-    mock_os_access.assert_called_once_with(mock_path.return_value, mocker.ANY)
-
-
-def test_md_file_to_docx_tool(mocker: "MockerFixture") -> None:
-    """md_file_to_docxツールのテスト。"""
-    mock_client = mocker.patch("middleman_ai.mcp.server.client")
-    mock_path = mocker.patch("middleman_ai.mcp.server.Path")
-    mock_os_access = mocker.patch("middleman_ai.mcp.server.os.access")
-    # mock_open を変数に束縛せず、Pathオブジェクトのopenメソッドのモックを設定
-    mock_file_handle = mocker.MagicMock()
-    mock_file_handle.read.return_value = "# Test MD"
-    mock_path.return_value.open.return_value.__enter__.return_value = mock_file_handle
-
-    mock_path.return_value.exists.return_value = True
-    mock_path.return_value.is_file.return_value = True
-    mock_client.md_to_docx.return_value = "https://example.com/test_file.docx"
-
-    file_path = "/fake/path/to/test.md"
-    result = md_file_to_docx(file_path)
-
-    assert result == "https://example.com/test_file.docx"
-    mock_path.assert_called_once_with(file_path)
-    mock_path.return_value.open.assert_called_once_with("r")
-    mock_client.md_to_docx.assert_called_once_with("# Test MD")
-    mock_os_access.assert_called_once_with(mock_path.return_value, mocker.ANY)

--- a/tests/vcr_utils.py
+++ b/tests/vcr_utils.py
@@ -1,0 +1,32 @@
+# VCRテストでは、例えばSTGに向けてテストした場合と本番に向けてテストした場合など
+# 環境差異によって生じるリクエスト内容の差異があるとエラーになってしまう
+# かといってリクエストボディを丸ごとignoreするとテストにならないので
+# 環境差異を吸収するための関数をここに定義し、
+# それぞれのテストで環境差異が発生する部分をマスクしてカセットを登録できるようにする
+
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+
+def _filter_value_in_request_body(request: Any, key: str, replace_value: str) -> Any:
+    """
+    共通ロジック：
+    リクエストボディが JSON である場合、一致する key があれば置き換える
+    """
+    try:
+        body = json.loads(request.body.decode())
+    except Exception:
+        return request
+    if key in body:
+        body[key] = replace_value
+        request.body = json.dumps(body).encode()
+    return request
+
+
+def generate_filter_request_body_function(key: str, replace_value: str) -> Callable:
+    """
+    VCRテストで環境依存な値をマスクするための関数（リクエストボディ用）
+    """
+    return lambda request: _filter_value_in_request_body(request, key, replace_value)

--- a/tests/vcr_utils.py
+++ b/tests/vcr_utils.py
@@ -4,10 +4,11 @@
 # 環境差異を吸収するための関数をここに定義し、
 # それぞれのテストで環境差異が発生する部分をマスクしてカセットを登録できるようにする
 
-
+import copy
 import json
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 
 def _filter_value_in_request_body(request: Any, key: str, replace_value: str) -> Any:
@@ -25,8 +26,77 @@ def _filter_value_in_request_body(request: Any, key: str, replace_value: str) ->
     return request
 
 
-def generate_filter_request_body_function(key: str, replace_value: str) -> Callable:
+def _generate_filter_request_body_function(key: str, replace_value: str) -> Callable:
     """
     VCRテストで環境依存な値をマスクするための関数（リクエストボディ用）
     """
     return lambda request: _filter_value_in_request_body(request, key, replace_value)
+
+
+def _mask_request_uri(request: Any) -> Any:
+    """
+    本番環境以外のURLが露出することを避けるなどカセットに秘匿情報が出ないための処置を行う
+    """
+    req = copy.deepcopy(request)
+    p = urlparse(req.uri)
+    redacted = urlunparse(
+        (p.scheme, "middleman-ai.com", p.path, p.params, p.query, p.fragment)
+    )
+    req.uri = redacted
+    return req
+
+
+def scrub_request(request: Any) -> Any:
+    """
+    環境差異によってエラーが発生しないよう、環境依存のパラメータの値をカセットに記録する差異に統一する
+    また、
+    """
+    # リクエストのURI からホスト名を標準化してmiddleman-ai.comに置換する
+    # 本番環境以外のURLが露出することを避けるための処置です
+    req = _mask_request_uri(request)
+
+    p = urlparse(req.uri)
+    request_path = p.path
+    if "md-to-pdf" in request_path:
+        req = _filter_value_in_request_body(req, "pdf_template_id", "TEMPLATE_ID")
+    if "md-to-docx" in request_path:
+        req = _filter_value_in_request_body(req, "docx_template_id", "TEMPLATE_ID")
+    if "json-to-pptx" in request_path:
+        req = _filter_value_in_request_body(req, "pptx_template_id", "TEMPLATE_ID")
+    return req
+
+
+def scrub_response(response: Any) -> Any:
+    """レスポンスの機密情報や環境依存情報を削除・置換する
+
+    特定のヘッダー（x-middleware-rewrite, x-request-id など）を削除し、
+    レスポンス中のURLを標準化します。
+    """
+    # レスポンス本体のディープコピーを作成
+    resp = copy.deepcopy(response)
+
+    # 環境依存の情報が含まれるヘッダーを削除または置換
+    headers_to_filter = [
+        "x-middleware-rewrite",
+        "x-request-id",
+        "date",
+        "server",
+    ]
+
+    for header in headers_to_filter:
+        if header in resp["headers"]:
+            resp["headers"][header] = ["FILTERED"]
+
+    # リダイレクト先URLがあればそれも標準化
+    if "location" in resp["headers"]:
+        location = resp["headers"]["location"][0]
+        p = urlparse(location)
+        if p.netloc and "middleman-ai.com" in p.netloc:
+            standardized = urlunparse(
+                (p.scheme, "middleman-ai.com", p.path, p.params, p.query, p.fragment)
+            )
+            resp["headers"]["location"] = [standardized]
+
+    # レスポンス本文内のURLパターンも置換できますが、ここでは実装していません
+
+    return resp

--- a/tests/vcr_utils.py
+++ b/tests/vcr_utils.py
@@ -49,7 +49,6 @@ def _mask_request_uri(request: Any) -> Any:
 def scrub_request(request: Any) -> Any:
     """
     環境差異によってエラーが発生しないよう、環境依存のパラメータの値をカセットに記録する差異に統一する
-    また、
     """
     # リクエストのURI からホスト名を標準化してmiddleman-ai.comに置換する
     # 本番環境以外のURLが露出することを避けるための処置です


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - MarkdownからDOCXおよびPDFへの変換コマンド・APIでテンプレートID指定に対応しました。
  - DOCX変換ツールでデフォルトテンプレートIDの設定が可能になりました。
  - 不正リクエスト時のエラー（BadRequestError）を追加しました。

- **バグ修正**
  - テスト用カセットや環境変数名の統一、および環境依存値のマスキング処理を追加しました。

- **ドキュメント**
  - 設定例や環境変数名をより汎用的な表記に修正しました。

- **テスト**
  - テンプレートID指定のテストケースを追加し、テスト関数名を統一しました。
  - VCRユーティリティの導入により、環境依存情報のマスキングを強化しました。

- **リファクタ**
  - テストコードの整理・パラメータ化と、内部呼び出し方法の統一を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->